### PR TITLE
fix: reapply frame style if state changes in NativeLookWindow

### DIFF
--- a/compose-native-look/src/jvmMain/kotlin/com/github/composenativelook/NativeLookWindow.kt
+++ b/compose-native-look/src/jvmMain/kotlin/com/github/composenativelook/NativeLookWindow.kt
@@ -60,7 +60,7 @@ fun NativeLookWindow(
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,
         ) {
-            val manager = remember {
+            val manager = remember(window) {
                 WindowStyleManager(
                     window,
                     preferredBackdropType,
@@ -79,6 +79,11 @@ fun NativeLookWindow(
             LaunchedEffect(preferredBackdropType) {
                 // TODO: to explore if manager can be totally removed
                 appliedBackdrop = manager.apply()
+            }
+
+            LaunchedEffect(frameStyle) {
+                manager.frameStyle = frameStyle
+                manager.apply()
             }
 
             @Suppress("NAME_SHADOWING")

--- a/compose-native-look/src/jvmMain/kotlin/com/github/composenativelook/WindowStyleManager.kt
+++ b/compose-native-look/src/jvmMain/kotlin/com/github/composenativelook/WindowStyleManager.kt
@@ -14,7 +14,7 @@ internal interface WindowStyleManager {
     /**
      * The style of the window frame which includes the title bar and window border. See [WindowFrameStyle].
      */
-    val frameStyle: WindowFrameStyle
+    var frameStyle: WindowFrameStyle
 
     suspend fun apply(): WindowBackdrop
 }


### PR DESCRIPTION
Updating the frame style passed to NativeLookWindow wasn't updating the underlying style since WindowStyleManager wasn't reacting to changes.